### PR TITLE
Install from composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,9 @@
 {
+	"name": "intervolga/migrato",
+    "description": "bitrix database migration module",
+    "type": "bitrix-d7-module",
 	"require": {
-	  "symfony/console": "3.2"
+		"symfony/console": "3.2",
+		"composer/installers": "~1.0"
 	}
 }


### PR DESCRIPTION
В composer.json добавил строки для получения модуля через composer. Пример composer.json проекта в который устанавливается модуль (нужно прописать свой github токен):

`
{
    "name": "yourname/projectname",
    "type": "project",
    "authors": [
        {
            "name": "Your Name",
            "email": "your@email.ru"
        }
    ],
    "require": {
        "intervolga/migrato": "dev-feature/install-from-composer"
    },
    "extra": {
        "installer-paths": {
            "public/local/modules/{$vendor}.{$name}/": ["type:bitrix-d7-module"]
        }
    },
    "config": {
    	"github-oauth": {
		"github.com": "your-github-token"
	}
    },
    "repositories": [
        {
            "type": "vcs",
            "url":  "git@github.com:gdecider/intervolga.migrato.git"
        }        
    ]
}
`

Секция "installer-paths" добавлена т.к. у меня гит и композер находятся на ровне с публичной папкой в которой живет битрикс.