### PR TITLE
Чтобы была возможность работать из корня

### DIFF
--- a/include.php
+++ b/include.php
@@ -4,4 +4,4 @@ $root = \Bitrix\Main\Application::getDocumentRoot();
 define("INTERVOLGA_MIGRATO_DIRECTORY", $root . "/local/migrato/");
 define("INTERVOLGA_MIGRATO_CONFIG_PATH", INTERVOLGA_MIGRATO_DIRECTORY . "config.xml");
 
-include 'vendor/autoload.php';
+include __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
Чтобы была возможность работать из корня через команду
ln -s bitrix/modules/intervolga.migrato/tools/run.php migrato

Например экспорт удобный:
php migrato export

Без этого коммита, если в корне сайта есть файл vendor/autoload.php, то подключается он. А там нет нужных зависимостей